### PR TITLE
Add parseSpotifyLink function

### DIFF
--- a/TrackList/spotify/index.ts
+++ b/TrackList/spotify/index.ts
@@ -8,6 +8,18 @@ import { fetchToken } from "../spotify/auth";
 
 const SEARCH_URL = "https://api.spotify.com/v1/search";
 
+/**
+ * Helper function that parses a spotify link to extract item type and item ID
+ * @param link 
+ * @returns itemType(playlist, track, etc.), ItemID
+ */
+export async function parseSpotifyLink(link: string) {
+  const splitLink = link.split("/")
+  const itemType = splitLink[3];
+  const itemID = splitLink[4].split("?")[0];
+  return { itemType, itemID };
+};
+
 // Usage:
 // Import searchAlbums from "./spotify/index" and call it with a search query string.
 // Example:


### PR DESCRIPTION
Added the parseSpotifyLink function to extract the item type (playlist, track, etc.) and itemID from a spotify share link with format:
https://open.spotify.com/ {ITEM_TYPE} / {ITEM_ID} ...
Test ran using trackById function:
![Screenshot 2025-03-14 181419](https://github.com/user-attachments/assets/efd97171-06a2-4149-b2d3-dc307617a27a)
Code that ran the test:
![Screenshot 2025-03-14 181443](https://github.com/user-attachments/assets/323a92c1-6f5f-4b18-8008-07296b67710a)
