### PR TITLE
Add album art to /spotify search

### DIFF
--- a/TrackList/app/spotify.tsx
+++ b/TrackList/app/spotify.tsx
@@ -14,6 +14,7 @@ interface Track {
 interface Album {
   id: string;
   name: string;
+  image: string;
 }
 
 export default function AlbumSearch() {
@@ -106,7 +107,11 @@ export default function AlbumSearch() {
       <div style={ {marginTop: "16px"} }>
         {albums.map((album) => (
           <div key={album.id} style={styles.albumCard}>
-            <p style={styles.albumName}>{album.name}</p>
+            <p style={styles.albumName}>{album.name}
+              <div>
+                <img src={album.image} style={styles.albumImage}></img>
+              </div>
+            </p>
             <button
               onClick={!showTracks[album.id] ? () => (fetchTracks(album.id), setShowTracks(() => ({[album.id]: true}))) : () => setShowTracks(() => ({[album.id]: false}))}
               style={{ color: "white", background: "none", borderRadius: 5, cursor: "pointer", backgroundColor: "#FF8001" }}
@@ -179,4 +184,8 @@ const styles = StyleSheet.create({
     paddingLeft: 8,
     paddingBottom: 8,
   },
+  albumImage: {
+    width: "50%",
+    height: "auto",
+  }
 });

--- a/TrackList/spotify/index.ts
+++ b/TrackList/spotify/index.ts
@@ -32,7 +32,12 @@ export const searchAlbums = async (query: string) => {
     headers: { Authorization: `Bearer ${token}` },
   });
   const data = await response.json();
-  return data.albums?.items || [];
+  return data.albums.items.map((album: any) => ({
+    id: album.id,
+    name: album.name,
+    artist: album.artists.map((artist: any) => artist.name).join(", "),
+    image: album.images[0]?.url,
+  })) || [];
 };
 
 const ALBUM_TRACKS_URL = "https://api.spotify.com/v1/albums";


### PR DESCRIPTION
Added album art to both New Releases and Search in the /spotify page. 

### New Releases

<img width="400" alt="Screenshot 2025-04-22 at 12 02 13 PM" src="https://github.com/user-attachments/assets/54c968d0-af9c-4a70-81a3-3690d11bbb38" />

### Search

<img width="400" alt="Screenshot 2025-04-22 at 12 03 26 PM" src="https://github.com/user-attachments/assets/cbf02ff9-2b81-44c5-b223-785a2e5936c5" />
